### PR TITLE
revert(eslint/base): turn off no underscore dangle

### DIFF
--- a/packages/eslint-config-base/recommended.mjs
+++ b/packages/eslint-config-base/recommended.mjs
@@ -208,7 +208,6 @@ export default [
           ],
         },
       ],
-      'no-underscore-dangle': 'off',
     },
   },
   {


### PR DESCRIPTION
Reverts pastelhk/pastel-ts-coding-standard#17

Since only this change is not sufficient to allow type-use only schema to pass eslint (due to naming convention), and also introduce further risks on bad naming not being detected, decided to keep this rule on and disable for `@typescript-eslint/no-unused-vars` when needed